### PR TITLE
Disable direct access to aws_static_site bucket

### DIFF
--- a/aws_static_site/cloudfront.tf
+++ b/aws_static_site/cloudfront.tf
@@ -21,6 +21,14 @@ resource "aws_cloudfront_distribution" "this" {
       origin_protocol_policy = "http-only"
       origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
     }
+
+    # Our S3 bucket will only allow requests containing this custom header.
+    # Somewhat perplexingly, this is the "correct" way to ensure users can't bypass CloudFront on their way to S3 resources.
+    # https://abridge2devnull.com/posts/2018/01/restricting-access-to-a-cloudfront-s3-website-origin/
+    custom_header {
+      name  = "User-Agent"
+      value = "${random_string.s3_read_password.result}"
+    }
   }
 
   # Define how to serve the content to clients

--- a/aws_static_site/data.tf
+++ b/aws_static_site/data.tf
@@ -1,3 +1,8 @@
 data "aws_route53_zone" "this" {
   name = "${replace("${var.site_domain}", "/.*\\b(\\w+\\.\\w+)\\.?$/", "$1")}" # e.g. "foo.example.com" => "example.com"
 }
+
+resource "random_string" "s3_read_password" {
+  length  = 32
+  special = false
+}

--- a/aws_static_site/s3.tf
+++ b/aws_static_site/s3.tf
@@ -41,7 +41,12 @@ resource "aws_s3_bucket_policy" "this" {
       "Effect": "Allow",
       "Principal": "*",
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::${local.bucket_name}/*"
+      "Resource": "arn:aws:s3:::${local.bucket_name}/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:UserAgent": "${random_string.s3_read_password.result}"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
This makes a lot of sense, especially when using HTTP Basic Auth.